### PR TITLE
Added .$inject list to prevent problems during JS minification

### DIFF
--- a/angular.hammer.js
+++ b/angular.hammer.js
@@ -170,6 +170,7 @@
       }
     };
   }
+  hammerCustomDirective.$inject = ['$parse'];
 
   // ---- Private Functions -----
 


### PR DESCRIPTION
Minification fails due to the parameter list in `hammerCustomDirective`. The fix is to provide the `$inject` array for this function.
