### PR TITLE
Fix bug with some minification tools

### DIFF
--- a/angular.hammer.js
+++ b/angular.hammer.js
@@ -170,7 +170,6 @@
       }
     };
   }
-  hammerCustomDirective.$inject = ['$parse'];
 
   // ---- Private Functions -----
 


### PR DESCRIPTION
The dependencies should be explicitly declared to avoid bug with some minification tools (like grunt-contrib-uglify).

I have replaced the fix made by @jogloran in #1 

You may need to rebuild your minify version.
