### PR TITLE
Removing explicitly stating where angular and hammer are.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,6 @@
     ]
   },
   "browser": {
-    "angular": "./node_modules/angular/angular.js",
-    "hammerjs": "./node_modules/hammerjs/hammer.js",
     "angular-hammer": "./angular.hammer.js"
   },
   "browserify-shim": {


### PR DESCRIPTION
This causes issues with browserify, especially as the dependencies are listed as dev dependencies so NPM doesn't download them. I left angular-hammer as it is as it doesn't seem to cause any issues.