### PR TITLE
Fix object error for when recognizeWith is added to addRecognizer. 

### DIFF
--- a/angular.hammer.js
+++ b/angular.hammer.js
@@ -390,7 +390,7 @@
       var recognizeWithRecognizer;
 
       if (manager.get(options.recognizeWith) == null){
-        recognizeWithRecognizer = addRecognizer(manager, {type:options.recognizeWith});
+        recognizeWithRecognizer = addRecognizer(manager, options.recognizeWith);
       }
 
       if (recognizeWithRecognizer != null) {


### PR DESCRIPTION
Fix object error for when recognizeWith is added to addRecognizer. The error is a result of changes to https://github.com/RyanMullins/angular-hammer/commit/1fd0dcb5b2ac6de69e3cdb267f79fd5a93a2b548