### PR TITLE
Made angular-hammer usable with Browserify

### DIFF
--- a/angular.hammer.js
+++ b/angular.hammer.js
@@ -6,16 +6,16 @@
 // (fairly heavy) modifications by James Wilson <me@unbui.lt>
 //
 
-(function (window, angular, Hammer) {
+(function (angular, Hammer) {
   'use strict';
 
   // Checking to make sure Hammer and Angular are defined
 
   if (typeof angular === 'undefined') {
-    throw Error("angular-hammer: AngularJS (window.angular) is undefined but is necessary.");
+    throw Error("angular-hammer: AngularJS (angular) is undefined but is necessary.");
   }
   if (typeof Hammer === 'undefined') {
-    throw Error("angular-hammer: HammerJS (window.Hammer) is undefined but is necessary.");
+    throw Error("angular-hammer: HammerJS (Hammer) is undefined but is necessary.");
   }
 
   /**
@@ -598,4 +598,4 @@
       }
     }
   }
-})(window, window.angular, window.Hammer);
+})(angular, Hammer);

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+module.exports = 'hmTouchEvents';
+
+var angular = require('angular');
+Hammer = require('hammerjs');
+require('./angular.hammer')

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-hammer",
   "version": "2.2.0",
   "description": "Hammer.js support for Angular.js applications",
-  "main": "angular.hammer.js",
+  "main": "index.js",
   "directories": {
     "example": "examples"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-hammer",
-  "version": "2.2-jsdw",
+  "version": "2.2.0",
   "description": "Hammer.js support for Angular.js applications",
   "main": "angular.hammer.js",
   "directories": {
@@ -26,8 +26,11 @@
     "url": "https://github.com/jsdw/angular-hammer/issues"
   },
   "homepage": "http://ryanmullins.github.io/angular-hammer/",
+  "dependencies": {
+      "angular": ">=1.2.0",
+      "hammerjs": ">=2.0.0"
+  },
   "devDependencies": {
-    "angular": ">=1.2.0",
     "browserify": "^8.0.3",
     "browserify-shim": "^3.8.2",
     "finalhandler": "^0.3.2",
@@ -41,7 +44,6 @@
     "grunt-jsdoc": "^0.5.7",
     "grunt-nodemon": "^0.3.0",
     "grunt-webpack": "^1.0.8",
-    "hammerjs": ">=2.0.0",
     "serve-static": "^1.7.1",
     "uglify-save-license": "^0.4.1",
     "webpack": "^1.4.15",


### PR DESCRIPTION
* Including Optimization for Angular module dependency notation supporting Browserify (http://blog.npmjs.org/post/114584444410/using-angulars-new-improved-browserify-support)